### PR TITLE
fix(empty form field): allows empty form field when submit through admin

### DIFF
--- a/ndarraydjango/fields.py
+++ b/ndarraydjango/fields.py
@@ -80,6 +80,13 @@ class NDArrayField(models.BinaryField):
         return parse_numpy_array(value)
 
     def validate(self, value, model_instance):
+        
+        if (
+            ( value is None and self.blank ) or 
+            ( value is None and self.null  )
+        ):
+            return
+
         if self.shape is not None and value.shape != self.shape:
             raise exceptions.ValidationError("Bad shape", code="shape")
 
@@ -103,6 +110,11 @@ class NDArrayField(models.BinaryField):
             return value
 
         if isinstance(value, str):
+            if (
+                ( value=='' and self.blank ) or 
+                ( value=='' and self.null  )
+            ):
+                return None
             try:
                 value = np.array(json.loads(value), dtype=self.dtype)
             except json.decoder.JSONDecodeError:

--- a/ndarraydjango/forms.py
+++ b/ndarraydjango/forms.py
@@ -30,6 +30,8 @@ class NDArrayFormField(forms.CharField):
 
     def to_python(self, value):
         value = super().to_python(value)
+        if (value==self.empty_value) and (not self.required):
+            return value
         try:
             value = json.loads(value)
         except json.decoder.JSONDecodeError:


### PR DESCRIPTION
- when editting a model with NDArrayField blank or null True through the admin panel, the form sends an empty str which was marked as invalid.
- Now field validation allows handling that case by treating value as None